### PR TITLE
added support for single-line functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 gocontracts/*.coverprofile
+*.coverprofile
+gocontracts/testcases/*.coverprofile

--- a/gocontracts/process_test.go
+++ b/gocontracts/process_test.go
@@ -18,6 +18,7 @@ var cases = []testcases.Case{
 	testcases.HasPrecondition,
 	testcases.HasPostcondition,
 	testcases.CurlyBracketsOnSameLine,
+	testcases.OneLineFunction,
 	testcases.HasOnlyComment,
 	testcases.SemicolonAfterPostcondition,
 	testcases.CommentAfterPostcondition,
@@ -98,7 +99,7 @@ func lastCommon(expected string, got string) (i int, found bool) {
 
 func TestProcess(t *testing.T) {
 	for _, cs := range cases {
-		updated, err := Process(cs.Text, cs.Remove)
+		updated, err := Process(cs.Text, cs.ID, cs.Remove)
 		if err != nil {
 			t.Fatalf("Failed at case %s: %s", cs.ID, err.Error())
 		}
@@ -120,7 +121,7 @@ func TestProcess(t *testing.T) {
 
 func TestProcessFailures(t *testing.T) {
 	for _, failure := range failures {
-		_, err := Process(failure.Text, false)
+		_, err := Process(failure.Text, failure.ID, false)
 
 		if err == nil {
 			t.Fatalf("Expected an error in the failure case %s, but got nil", failure.ID)

--- a/gocontracts/testcases/case_one_line_function.go
+++ b/gocontracts/testcases/case_one_line_function.go
@@ -1,0 +1,57 @@
+package testcases
+
+// OneLineFunction tests that condition checks are correctly generated in a function implemented on
+// a single line.
+var OneLineFunction = Case{
+	ID: "one_line_function",
+	Text: `package somepkg
+
+// SomeFunc does something.
+//
+// SomeFunc requires:
+// * x > 0
+// * x < 100
+// * some condition: y > 3
+//
+// SomeFunc ensures:
+// * strings.HasPrefix(result, "hello")
+//
+// Some text here.
+func SomeFunc(x int, y int) (result string, err error) { return "" }
+`,
+	Expected: `package somepkg
+
+// SomeFunc does something.
+//
+// SomeFunc requires:
+// * x > 0
+// * x < 100
+// * some condition: y > 3
+//
+// SomeFunc ensures:
+// * strings.HasPrefix(result, "hello")
+//
+// Some text here.
+func SomeFunc(x int, y int) (result string, err error) {
+	// Pre-conditions
+	switch {
+	case !(x > 0):
+		panic("Violated: x > 0")
+	case !(x < 100):
+		panic("Violated: x < 100")
+	case !(y > 3):
+		panic("Violated: some condition: y > 3")
+	default:
+		// Pass
+	}
+
+	// Post-condition
+	defer func() {
+		if !(strings.HasPrefix(result, "hello")) {
+			panic("Violated: strings.HasPrefix(result, \"hello\")")
+		}
+	}()
+
+	return ""
+}
+`}


### PR DESCRIPTION
Single-line functions caused the assertion in updateNonemptyFunc (new: updateMultilineFunc) to panic: we put cursor at the first non-contract statement of the function body and move it back till we expected to reach either a new-line start or a semi-colon (';') indicating the end of the contract block.

However, when a single-line function was given, we would reach the left brace of the function definition like in this function:

```go
func SomeFunc(x int, y int) (result string, err error) { return "" }
```