### PR TITLE
Added blank line to build constraint examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The examples of the three files follow.
 `contracts_prod.go`:
 ```go
 // +build prod,!test,!utest
+
 package somepackage
 
 const InTest = false
@@ -167,6 +168,7 @@ const InUTest = false
 `contracts_test.go`:
 ```go
 // +build !prod,test,!utest
+
 package somepackage
 
 const InTest = true
@@ -176,6 +178,7 @@ const InUTest = false
 `contracts_utest.go`:
 ```go
 // +build !prod,!test,utest
+
 package somepackage
 
 const InTest = true


### PR DESCRIPTION
As specified in https://golang.org/pkg/go/build/#hdr-Build_Constraints: 

"To distinguish build constraints from package documentation, a series of build constraints must be followed by a blank line."