### PR TITLE
Changed sign of boolean InTest in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ tests, but not in production:
 // Range returns a range of the timestamps available in the database.
 //
 // Range ensures:
-//  * InTest && (err != nil || (empty || first <= last))
+//  * !InTest || (err != nil || (empty || first <= last))
 func (t *Txn) Range() (first int64, last int64, empty bool, err error) {
 	...
 }


### PR DESCRIPTION
If we want a condition `C` to be evaluated only when `InTest=true`, we ought to write:
`!InTest || C`

So that in production, the condition above is `true` as a consequence of `InTest=false`, with no need to check what follows.